### PR TITLE
Add INITRAMFS_IMAGE_BUNDLE = "1" to support loading a combined uImage…

### DIFF
--- a/base/adsp-sc589-mini/local.conf
+++ b/base/adsp-sc589-mini/local.conf
@@ -242,6 +242,9 @@ LICENSE_FLAGS_WHITELIST = "commercial non-commercial"
 # this doesn't mean anything to you.
 CONF_VERSION = "1"
 
+# Disable INITRAMFS_IMAGE_BUNDLE to split initramfs from uImage
+INITRAMFS_IMAGE_BUNDLE = "1"
+
 # This is only defined to build U-boot from external toolchain from CCES 
 # To build linux kernel and filesystem, you should comment this out
 # TCMODE = "external-adi"


### PR DESCRIPTION
Add INITRAMFS_IMAGE_BUNDLE = "1" to support loading a combined uImage with linux kernel and initramfs

Signed-off-by: huanhuan feng <huanhuan.feng@analog.com>