### PR TITLE
Added SOM and CRR Rev options to update the machine during setup

### DIFF
--- a/setup-environment
+++ b/setup-environment
@@ -166,32 +166,34 @@ fi
 
 # check whether the provided machine needs a SOM and CRR revision
 # if it exists, then -s and -c options must be provided. Update conf if provided
-if grep -wq 'SOM_REV' sources/meta-adi/meta-adi-adsp-sc5xx/conf/machine/"$MACHINE".conf ; then
-    if [ -z "$SOM_REV" ] ; then
-        echo "ERROR: SOM revision must be explicitly set for this machine."
-        clean_up
-        return 1
+if [ "$build_dir_not_exist" = "true" ] || [ -n "$MACHINE" ]; then
+    if grep -wq 'SOM_REV' sources/meta-adi/meta-adi-adsp-sc5xx/conf/machine/"$MACHINE".conf ; then
+        if [ -z "$SOM_REV" ] ; then
+            echo "ERROR: SOM revision must be explicitly set for this machine."
+            clean_up
+            return 1
+        fi
+    else
+        if [ -n "$SOM_REV" ]; then
+            echo "ERROR: SOM revision is not applicable to this machine."
+            clean_up
+            return 1
+        fi
     fi
-else
-    if [ -n "$SOM_REV" ]; then
-        echo "ERROR: SOM revision is not applicable to this machine."
-        clean_up
-        return 1
-    fi
-fi
 
 
-if grep -wq 'CRR_REV' sources/meta-adi/meta-adi-adsp-sc5xx/conf/machine/"$MACHINE".conf ; then
-    if [ -z "$CRR_REV" ] ; then
-        echo "ERROR: CRR revision must be explicitly set for this machine."
-        clean_up
-        return 1
-    fi
-else
-    if [ -n "$CRR_REV" ]; then
-        echo "ERROR: CRR revision is not applicable to this machine."
-        clean_up
-        return 1
+    if grep -wq 'CRR_REV' sources/meta-adi/meta-adi-adsp-sc5xx/conf/machine/"$MACHINE".conf ; then
+        if [ -z "$CRR_REV" ] ; then
+            echo "ERROR: CRR revision must be explicitly set for this machine."
+            clean_up
+            return 1
+        fi
+    else
+        if [ -n "$CRR_REV" ]; then
+            echo "ERROR: CRR revision is not applicable to this machine."
+            clean_up
+            return 1
+        fi
     fi
 fi
 

--- a/setup-environment
+++ b/setup-environment
@@ -47,6 +47,8 @@ Options:
     -m, --machine      Set the MACHINE name in the build configuration
     -b, --builddir     Set the build directory in the build configuration (default '${BUILDDIR_DEFAULT}')
     -d, --distro       Set the DISTRO name in the build configuration (default '${DISTRO_DEFAULT}')
+    -s, --somrev       Set the SOM revision in the build configuration
+    -c, --crrrev       Set the CRR revision in the build configuration
 
 The first usage is for creating a new build directory. In this case, the
 script creates the build directory <BUILDDIR>, configures it for the
@@ -80,8 +82,8 @@ clean_up()
 }
 
 # get command line options
-SHORTOPTS="hm:b:d:"
-LONGOPTS="help,machine:,builddir:,distro:"
+SHORTOPTS="hm:b:d:s:c:"
+LONGOPTS="help,machine:,builddir:,distro:,somrev:,crrrev:"
 
 ARGS=$(getopt --options $SHORTOPTS --longoptions $LONGOPTS --name $PROGNAME -- "$@" )
 # Print the usage menu if invalid options are specified
@@ -95,6 +97,8 @@ eval set -- "$ARGS"
 MACHINE=
 USER_BUILDDIR=
 DISTRO=
+SOM_REV=
+CRR_REV=
 
 while true;
 do
@@ -103,6 +107,8 @@ do
         -m | --machine)    MACHINE="$2"; shift 2;;
         -b | --builddir)   USER_BUILDDIR="$2"; shift 2;;
         -d | --distro)     DISTRO="$2"; shift 2;;
+        -s | --somrev)     SOM_REV="$2"; shift 2;;
+        -c | --crrrev)     CRR_REV="$2"; shift 2;;
         -- )               shift; break ;;
         * )                break ;;
     esac
@@ -156,6 +162,46 @@ if [ "$build_dir_not_exist" = "true" ] || [ -n "$DISTRO" ];then
         clean_up
         return 1
     fi
+fi
+
+# check whether the provided machine needs a SOM and CRR revision
+# if it exists, then -s and -c options must be provided. Update conf if provided
+if grep -wq 'SOM_REV' sources/meta-adi/meta-adi-adsp-sc5xx/conf/machine/"$MACHINE".conf ; then
+    if [ -z "$SOM_REV" ] ; then
+        echo "ERROR: SOM revision must be explicitly set for this machine."
+        clean_up
+        return 1
+    fi
+else
+    if [ -n "$SOM_REV" ]; then
+        echo "ERROR: SOM revision is not applicable to this machine."
+        clean_up
+        return 1
+    fi
+fi
+
+
+if grep -wq 'CRR_REV' sources/meta-adi/meta-adi-adsp-sc5xx/conf/machine/"$MACHINE".conf ; then
+    if [ -z "$CRR_REV" ] ; then
+        echo "ERROR: CRR revision must be explicitly set for this machine."
+        clean_up
+        return 1
+    fi
+else
+    if [ -n "$CRR_REV" ]; then
+        echo "ERROR: CRR revision is not applicable to this machine."
+        clean_up
+        return 1
+    fi
+fi
+
+if [ -n "$SOM_REV" ]; then
+    sed -e "s,SOM_REV = .*,SOM_REV = \"$SOM_REV\",g" \
+        -i sources/meta-adi/meta-adi-adsp-sc5xx/conf/machine/"$MACHINE".conf
+fi
+if [ -n "$CRR_REV" ]; then
+    sed -e "s,CRR_REV = .*,CRR_REV = \"$CRR_REV\",g" \
+        -i sources/meta-adi/meta-adi-adsp-sc5xx/conf/machine/"$MACHINE".conf
 fi
 
 if [ ! -e "$CWD"/downloads ];then


### PR DESCRIPTION
Certain ADI boards (such as the ADSP-SC598-SOM-EZKIT) have board revisions that are require their Machine.conf to be updated to the correct SOM and CCR Revision. If this is not correct, the first-time u-boot flash fails. 
This enhancement checks if $MACHINE.conf contains SOM_REV and CRR_REV and requires the user to explicitly enter the SOM and CRR revisions as setup options. The conf file is then updated with the entered revision.


 